### PR TITLE
Encapsulate or statements in search query with parenthesis

### DIFF
--- a/CourseSearchAPIHttpTrigger/query.py
+++ b/CourseSearchAPIHttpTrigger/query.py
@@ -58,7 +58,7 @@ class Query:
                 countries.append("course/country/code eq '" + country + "'")
 
             if len(countries) > 1:
-                filters.append(" or ".join(countries))
+                filters.append("("+ " or ".join(countries) + ")")
             else:
                 filters.append(countries[0])
 
@@ -122,7 +122,7 @@ class Query:
                     )
 
             if len(institution_list) > 1:
-                filters.append(" or ".join(institution_list))
+                filters.append("(" + " or ".join(institution_list) + ")")
             else:
                 filters.append(institution_list[0])
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@ beta-search-api
 =================
 Service to allow api customers to search for course resources.
 
+Builds
+
+master - [![Build Status](https://dev.azure.com/ofsbeta/discoverUni/_apis/build/status/prod/prod-search-api?branchName=master)](https://dev.azure.com/ofsbeta/discoverUni/_build/latest?definitionId=17&branchName=master)
+
+develop - [![Build Status](https://dev.azure.com/ofsbeta/discoverUni/_apis/build/status/dev/dev-search-api?branchName=develop)](https://dev.azure.com/ofsbeta/discoverUni/_build/latest?definitionId=31&branchName=develop)
+
+
 ### Configuration Settings
 
 Add the following to your local.settings.json:


### PR DESCRIPTION
### What

Fix bug whereby countries were competing with postcode in search query

### How to review

If you run application locally against development (azure search) and hit the following url:

http://localhost:7071/api/CourseSearchAPIHttpTrigger?countries=scotland,wales&postcode=hr29bp,50

You should now only get courses for teaching locations (institutions) in Wales as the postcode is not within 50 miles of Scotland
