### PR TITLE
Release/v0.1.1

### DIFF
--- a/CourseSearchAPIHttpTrigger/__init__.py
+++ b/CourseSearchAPIHttpTrigger/__init__.py
@@ -64,23 +64,33 @@ def main(req: func.HttpRequest) -> func.HttpResponse:
         institutions = req.params.get("institutions", "")
         countries = req.params.get("countries", "")
         length_of_course = req.params.get("length_of_course", "")
+        subjects = req.params.get("subjects", "")
 
         postcode_object = {}
         # Step 1 Lookup postcode if parameter is set
         if postcode_and_distance:
             postcode_params = postcode_and_distance.split(",")
             postcode_object = search.find_postcode(
-                search_url, api_key, api_version, postcode_index_name, postcode_params[0]
+                search_url,
+                api_key,
+                api_version,
+                postcode_index_name,
+                postcode_params[0],
             )
 
             postcode_object["distance"] = convert_miles_to_km(postcode_params[1])
 
         # Step 2 - Validate query parameters
         query_params, error_objects = validation.check_query_parameters(
-            countries, filters, length_of_course, limit, max_default_limit, offset
+            countries,
+            filters,
+            length_of_course,
+            subjects,
+            limit,
+            max_default_limit,
+            offset,
         )
 
-        logging.info(f"query_params: {query_params}")
         if error_objects:
             logging.error(
                 f"invalid filter options\n filter_options:\
@@ -109,6 +119,7 @@ def main(req: func.HttpRequest) -> func.HttpResponse:
             search_url, api_key, api_version, course_index_name, search_query
         )
 
+        logging.info(f"response:{response_with_facets}")
         facets = response_with_facets.json()
 
         counts = {}

--- a/CourseSearchAPIHttpTrigger/helper.py
+++ b/CourseSearchAPIHttpTrigger/helper.py
@@ -51,6 +51,7 @@ def group_courses_by_institution(search_results, counts, limit, offset):
             "mode": course["mode"]["label"],
             "qualification": course["qualification"]["label"],
             "sandwich_year": course["sandwich_year"]["label"],
+            "subjects": course["subjects"],
             "title": course["title"],
             "year_abroad": course["year_abroad"]["label"],
         }

--- a/CourseSearchAPIHttpTrigger/query.py
+++ b/CourseSearchAPIHttpTrigger/query.py
@@ -58,7 +58,7 @@ class Query:
                 countries.append("course/country/code eq '" + country + "'")
 
             if len(countries) > 1:
-                filters.append("("+ " or ".join(countries) + ")")
+                filters.append("(" + " or ".join(countries) + ")")
             else:
                 filters.append(countries[0])
 
@@ -84,12 +84,13 @@ class Query:
                 filters.append("course/honours_award_provision/code eq 0")
 
         if (
-            "length_of_courses" in self.query_params
-            and self.query_params["length_of_courses"]
+            "length_of_course" in self.query_params
+            and self.query_params["length_of_course"]
         ):
-
-            loc = ",".join(self.query_params["length_of_courses"])
-            filters.append("search.in(course/length_of_course/code. '" + loc + "')")
+            loc = ",".join(self.query_params["length_of_course"])
+            filters.append(
+                "search.in(course/length_of_course/code, '" + str(loc) + "')"
+            )
 
         if "part_time" in self.query_params:
             filters.append("course/mode/code eq 2")
@@ -99,6 +100,17 @@ class Query:
                 filters.append("course/sandwich_year/code ne 0")
             else:
                 filters.append("course/sandwich_year/code ne 2")
+
+        if "subjects" in self.query_params and self.query_params["subjects"]:
+            subjects = list()
+
+            for subject in self.query_params["subjects"]:
+                subjects.append("s/code eq '" + subject + "'")
+
+            if len(subjects) > 1:
+                filters.append("course/subjects/any(s: " + " or ".join(subjects) + ")")
+            else:
+                filters.append("course/subjects/any(s: " + subjects[0] + ")")
 
         if "year_abroad" in self.query_params:
             if self.query_params["year_abroad"]:

--- a/CourseSearchAPIHttpTrigger/search.py
+++ b/CourseSearchAPIHttpTrigger/search.py
@@ -66,9 +66,9 @@ class PostcodeIndex:
 
 
 def get_courses(url, api_key, api_version, index_name, search_query):
-        index = CourseIndex(url, api_key, api_version, index_name, search_query)
+    index = CourseIndex(url, api_key, api_version, index_name, search_query)
 
-        return index.get()
+    return index.get()
 
 
 class CourseIndex:

--- a/CourseSearchAPIHttpTrigger/tests/test_query_params_validation.py
+++ b/CourseSearchAPIHttpTrigger/tests/test_query_params_validation.py
@@ -20,7 +20,7 @@ class TestValidateLimit(unittest.TestCase):
     def test_when_limit_is_within_max_limit(self):
         limit = "10"
         max_limit = 100
-        validator = Validator("", "", "", limit, max_limit, "0")
+        validator = Validator("", "", "", "", limit, max_limit, "0")
 
         expected_result = 10
         output_result, output_error_object = validator.validate_limit()
@@ -30,7 +30,7 @@ class TestValidateLimit(unittest.TestCase):
     def test_when_limit_is_outside_max_limit(self):
         limit = "200"
         max_limit = 100
-        validator = Validator("", "", "", limit, max_limit, "0")
+        validator = Validator("", "", "", "", limit, max_limit, "0")
 
         expected_result = 200
         expected_error_object = [
@@ -47,7 +47,7 @@ class TestValidateLimit(unittest.TestCase):
     def test_when_limit_is_a_negative_number(self):
         limit = "-20"
         max_limit = 100
-        validator = Validator("", "", "", limit, max_limit, "0")
+        validator = Validator("", "", "", "", limit, max_limit, "0")
 
         expected_result = -20
         expected_error_object = [
@@ -64,7 +64,7 @@ class TestValidateLimit(unittest.TestCase):
     def test_when_limit_is_not_a_number(self):
         limit = "twenty"
         max_limit = 100
-        validator = Validator("", "", "", limit, max_limit, "0")
+        validator = Validator("", "", "", "", limit, max_limit, "0")
 
         expected_result = 0
         expected_error_object = [
@@ -82,7 +82,7 @@ class TestValidateLimit(unittest.TestCase):
 class TestValidateOffset(unittest.TestCase):
     def test_when_offset_is_a_positive_number(self):
         offset = "20"
-        validator = Validator("", "", "", "0", 100, offset)
+        validator = Validator("", "", "", "", "0", 100, offset)
 
         expected_result = 20
         output_result, output_error_object = validator.validate_offset()
@@ -92,7 +92,7 @@ class TestValidateOffset(unittest.TestCase):
 
     def test_when_offset_is_a_negative_number(self):
         offset = "-20"
-        validator = Validator("", "", "", "0", 100, offset)
+        validator = Validator("", "", "", "", "0", 100, offset)
 
         expected_result = -20
         expected_error_object = [
@@ -108,7 +108,7 @@ class TestValidateOffset(unittest.TestCase):
 
     def test_when_offset_is_not_a_number(self):
         offset = "twenty"
-        validator = Validator("", "", "", "0", 100, offset)
+        validator = Validator("", "", "", "", "0", 100, offset)
 
         expected_result = 0
         expected_error_object = [
@@ -126,7 +126,7 @@ class TestValidateOffset(unittest.TestCase):
 class TestValidateFilters(unittest.TestCase):
     def test_when_empty_filters_returns_no_error(self):
         filters = ""
-        validator = Validator("", filters, "", "0", 100, "0")
+        validator = Validator("", filters, "", "", "0", 100, "0")
 
         output_filters, output_error_object = validator.validate_filters()
 
@@ -135,7 +135,7 @@ class TestValidateFilters(unittest.TestCase):
 
     def test_when_a_filter_is_selected_returns_no_error(self):
         filters = "distance_learning"
-        validator = Validator("", filters, "", "0", 100, "0")
+        validator = Validator("", filters, "", "", "0", 100, "0")
 
         output_filters, output_error_object = validator.validate_filters()
         expected_filters = {"distance_learning": True}
@@ -145,7 +145,7 @@ class TestValidateFilters(unittest.TestCase):
 
     def test_when_a_filter_is_selected_prefixed_with_hyphen_returns_no_error(self):
         filters = "-sandwich_year"
-        validator = Validator("", filters, "", "0", 100, "0")
+        validator = Validator("", filters, "", "", "0", 100, "0")
 
         output_filters, output_error_object = validator.validate_filters()
         expected_filters = {"sandwich_year": False}
@@ -155,7 +155,7 @@ class TestValidateFilters(unittest.TestCase):
 
     def test_when_all_filters_are_selected_returns_no_error(self):
         filters = "-distance_learning,honours_award,foundation_year,sandwich_year,year_abroad,-full_time"
-        validator = Validator("", filters, "", "0", 100, "0")
+        validator = Validator("", filters, "", "", "0", 100, "0")
 
         output_filters, output_error_object = validator.validate_filters()
         expected_filters = {
@@ -172,7 +172,7 @@ class TestValidateFilters(unittest.TestCase):
 
     def test_when_there_are_duplicate_filters_returns_error(self):
         filters = "-distance_learning,distance_learning"
-        validator = Validator("", filters, "", "0", 100, "0")
+        validator = Validator("", filters, "", "", "0", 100, "0")
 
         output_filters, output_error_object = validator.validate_filters()
         expected_error_object = [
@@ -187,7 +187,7 @@ class TestValidateFilters(unittest.TestCase):
 
     def test_when_there_are_invalid_filters_returns_error(self):
         filters = "salary,distance_learning,PaRt-Time"
-        validator = Validator("", filters, "", "0", 100, "0")
+        validator = Validator("", filters, "", "", "0", 100, "0")
 
         output_filters, output_error_object = validator.validate_filters()
         expected_error_object = [
@@ -202,7 +202,7 @@ class TestValidateFilters(unittest.TestCase):
 
     def test_when_there_both_part_time_and_full_time_filters_set_returns_error(self):
         filters = "full_time,-part_time"
-        validator = Validator("", filters, "", "0", 100, "0")
+        validator = Validator("", filters, "", "", "0", 100, "0")
 
         output_filters, output_error_object = validator.validate_filters()
         expected_error_object = [
@@ -284,7 +284,7 @@ class TestValidateFilterOptions(unittest.TestCase):
 class TestValidateCountries(unittest.TestCase):
     def test_when_empty_countries_returns_no_error(self):
         countries = ""
-        validator = Validator(countries, "", "", "0", 100, "0")
+        validator = Validator(countries, "", "", "", "0", 100, "0")
 
         output_countries, output_error_object = validator.validate_countries()
 
@@ -293,7 +293,7 @@ class TestValidateCountries(unittest.TestCase):
 
     def test_when_england_is_selected_returns_no_error(self):
         countries = "england"
-        validator = Validator(countries, "", "", "0", 100, "0")
+        validator = Validator(countries, "", "", "", "0", 100, "0")
 
         output_countries, output_error_object = validator.validate_countries()
 
@@ -302,7 +302,7 @@ class TestValidateCountries(unittest.TestCase):
 
     def test_when_northern_ireland_is_selected_returns_no_error(self):
         countries = "northern_ireland"
-        validator = Validator(countries, "", "", "0", 100, "0")
+        validator = Validator(countries, "", "", "", "0", 100, "0")
 
         output_countries, output_error_object = validator.validate_countries()
 
@@ -311,7 +311,7 @@ class TestValidateCountries(unittest.TestCase):
 
     def test_when_scotland_is_selected_returns_no_error(self):
         countries = "scotland"
-        validator = Validator(countries, "", "", "0", 100, "0")
+        validator = Validator(countries, "", "", "", "0", 100, "0")
 
         output_countries, output_error_object = validator.validate_countries()
 
@@ -320,7 +320,7 @@ class TestValidateCountries(unittest.TestCase):
 
     def test_when_wales_is_selected_returns_no_error(self):
         countries = "wales"
-        validator = Validator(countries, "", "", "0", 100, "0")
+        validator = Validator(countries, "", "", "", "0", 100, "0")
 
         output_countries, output_error_object = validator.validate_countries()
 
@@ -329,7 +329,7 @@ class TestValidateCountries(unittest.TestCase):
 
     def test_when_multiple_countries_are_selected_returns_no_error(self):
         countries = "england,wales"
-        validator = Validator(countries, "", "", "0", 100, "0")
+        validator = Validator(countries, "", "", "", "0", 100, "0")
 
         output_countries, output_error_object = validator.validate_countries()
 
@@ -338,7 +338,7 @@ class TestValidateCountries(unittest.TestCase):
 
     def test_when_a_country_is_selected_prefixed_with_hyphen_returns_no_error(self):
         countries = "-england"
-        validator = Validator(countries, "", "", "0", 100, "0")
+        validator = Validator(countries, "", "", "", "0", 100, "0")
 
         output_countries, output_error_object = validator.validate_countries()
 
@@ -347,7 +347,7 @@ class TestValidateCountries(unittest.TestCase):
 
     def test_when_there_are_duplicate_countries_returns_error(self):
         countries = "england,-england"
-        validator = Validator(countries, "", "", "0", 100, "0")
+        validator = Validator(countries, "", "", "", "0", 100, "0")
 
         output_countries, output_error_object = validator.validate_countries()
         expected_error_object = [
@@ -362,7 +362,7 @@ class TestValidateCountries(unittest.TestCase):
 
     def test_when_there_are_invalid_uk_countries_returns_error(self):
         countries = "bosnia,photosynthesis,england"
-        validator = Validator(countries, "", "", "0", 100, "0")
+        validator = Validator(countries, "", "", "", "0", 100, "0")
 
         output_countries, output_error_object = validator.validate_countries()
         expected_error_object = [
@@ -450,76 +450,76 @@ class TestIsInt(unittest.TestCase):
 
 
 class TestValidateLengthOfCourse(unittest.TestCase):
-    def test_when_empty_length_of_courses_returns_no_error(self):
-        length_of_courses = ""
-        validator = Validator("", "", length_of_courses, "0", 100, "0")
+    def test_when_empty_length_of_course_returns_no_error(self):
+        length_of_course = ""
+        validator = Validator("", "", length_of_course, "", "0", 100, "0")
 
-        output_lengths, output_error_object = validator.validate_length_of_courses()
+        output_lengths, output_error_object = validator.validate_length_of_course()
 
         self.assertEqual([], output_lengths)
         self.assertEqual([], output_error_object)
 
     def test_when_a_valid_length_of_course_returns_no_error(self):
-        length_of_courses = "4"
-        validator = Validator("", "", length_of_courses, "0", 100, "0")
+        length_of_course = "4"
+        validator = Validator("", "", length_of_course, "", "0", 100, "0")
 
-        output_lengths, output_error_object = validator.validate_length_of_courses()
+        output_lengths, output_error_object = validator.validate_length_of_course()
 
-        self.assertEqual([4], output_lengths)
+        self.assertEqual(["4"], output_lengths)
         self.assertEqual([], output_error_object)
 
-    def test_when_multiple_valid_length_of_courses_returns_no_error(self):
-        length_of_courses = "1,7"
-        validator = Validator("", "", length_of_courses, "0", 100, "0")
+    def test_when_multiple_valid_length_of_course_returns_no_error(self):
+        length_of_course = "1,7"
+        validator = Validator("", "", length_of_course, "", "0", 100, "0")
 
-        output_lengths, output_error_object = validator.validate_length_of_courses()
+        output_lengths, output_error_object = validator.validate_length_of_course()
 
-        self.assertEqual([1, 7], output_lengths)
+        self.assertEqual(["1", "7"], output_lengths)
         self.assertEqual([], output_error_object)
 
-    def test_when_length_of_courses_is_not_a_number_returns_error(self):
-        length_of_courses = "four,3"
-        validator = Validator("", "", length_of_courses, "0", 100, "0")
+    def test_when_length_of_course_is_not_a_number_returns_error(self):
+        length_of_course = "four,3"
+        validator = Validator("", "", length_of_course, "", "0", 100, "0")
 
-        output_lengths, output_error_object = validator.validate_length_of_courses()
+        output_lengths, output_error_object = validator.validate_length_of_course()
         expected_error_object = [
             {
                 "error": "length_of_course values needs to be a number",
-                "error_values": [{"length_of_courses": "four"}],
+                "error_values": [{"length_of_course": "four"}],
             }
         ]
 
         self.assertEqual([], output_lengths)
         self.assertEqual(expected_error_object, output_error_object)
 
-    def test_when_length_of_courses_is_above_maximum_number_of_years_returns_error(
+    def test_when_length_of_course_is_above_maximum_number_of_years_returns_error(
         self
     ):
-        length_of_courses = "8"
-        validator = Validator("", "", length_of_courses, "0", 100, "0")
+        length_of_course = "8"
+        validator = Validator("", "", length_of_course, "", "0", 100, "0")
 
-        output_lengths, output_error_object = validator.validate_length_of_courses()
+        output_lengths, output_error_object = validator.validate_length_of_course()
         expected_error_object = [
             {
                 "error": "length_of_course values needs to be numbers between the range of 1 and 7",
-                "error_values": [{"length_of_courses": "8"}],
+                "error_values": [{"length_of_course": "8"}],
             }
         ]
 
         self.assertEqual([], output_lengths)
         self.assertEqual(expected_error_object, output_error_object)
 
-    def test_when_length_of_courses_is_above_minimum_number_of_years_returns_error(
+    def test_when_length_of_course_is_above_minimum_number_of_years_returns_error(
         self
     ):
-        length_of_courses = "0"
-        validator = Validator("", "", length_of_courses, "0", 100, "0")
+        length_of_course = "0"
+        validator = Validator("", "", length_of_course, "", "0", 100, "0")
 
-        output_lengths, output_error_object = validator.validate_length_of_courses()
+        output_lengths, output_error_object = validator.validate_length_of_course()
         expected_error_object = [
             {
                 "error": "length_of_course values needs to be numbers between the range of 1 and 7",
-                "error_values": [{"length_of_courses": "0"}],
+                "error_values": [{"length_of_course": "0"}],
             }
         ]
 
@@ -532,9 +532,10 @@ class TestValidate(unittest.TestCase):
         limit = 5
         offset = "30"
         filters = "distance_learning,honours_award,-foundation_year,sandwich_year,-year_abroad,full_time"
-        length_of_courses = "3,4"
+        length_of_course = "3,4"
         countries = "england,wales"
-        validator = Validator(countries, filters, length_of_courses, limit, 100, offset)
+        subjects = "CAH09-01-01,CAH09-01-02"
+        validator = Validator(countries, filters, length_of_course, subjects, limit, 100, offset)
 
         expected_result = {
             "countries": ["XF", "XI"],
@@ -542,11 +543,12 @@ class TestValidate(unittest.TestCase):
             "foundation_year": False,
             "full_time": True,
             "honours_award": True,
-            "length_of_courses": [3, 4],
+            "length_of_course": ["3", "4"],
             "limit": 5,
             "offset": 30,
             "sandwich_year": True,
-            "year_abroad": False,
+            "subjects": ["CAH09-01-01", "CAH09-01-02"],
+            "year_abroad": False
         }
         output_result, output_error_object = validator.validate()
 
@@ -557,9 +559,10 @@ class TestValidate(unittest.TestCase):
         limit = 200
         offset = "-30"
         filters = "illusion,Part_Time,full_time,-full_time"
-        length_of_courses = "-2,8,twenty"
+        length_of_course = "-2,8,twenty"
         countries = "bolivia,-england,england"
-        validator = Validator(countries, filters, length_of_courses, limit, 100, offset)
+        subjects = 32
+        validator = Validator(countries, filters, length_of_course, subjects, limit, 100, offset)
 
         expected_result = {}
         output_result, output_error_object = validator.validate()
@@ -587,12 +590,12 @@ class TestValidate(unittest.TestCase):
             {"error": "invalid countries", "error_values": [{"countries": "bolivia"}]},
             {
                 "error": "length_of_course values needs to be a number",
-                "error_values": [{"length_of_courses": "twenty"}],
+                "error_values": [{"length_of_course": "twenty"}],
             },
             {
                 "error": "length_of_course values needs to be numbers between the range of 1 and 7",
-                "error_values": [{"length_of_courses": "-2,8"}],
-            },
+                "error_values": [{"length_of_course": "-2,8"}],
+            }
         ]
 
         print(f"output: {output_error_object}")

--- a/CourseSearchAPIHttpTrigger/validation.py
+++ b/CourseSearchAPIHttpTrigger/validation.py
@@ -58,7 +58,7 @@ class Validator:
         self.new_offset, o_error_objects = self.validate_offset()
         self.new_filters, f_error_objects = self.validate_filters()
         self.new_countries, c_error_objects = self.validate_countries()
-        self.new_length_of_course, loc_error_objects = self.validate_length_of_courses()
+        self.new_length_of_course, loc_error_objects = self.validate_length_of_course()
 
         # Combine error objects
         error_objects.extend(
@@ -259,7 +259,7 @@ class Validator:
 
         return must_have_countries, []
 
-    def validate_length_of_courses(self):
+    def validate_length_of_course(self):
         error_objects = []
         if self.length_of_course == "":
             return [], []

--- a/CourseSearchAPIHttpTrigger/validation.py
+++ b/CourseSearchAPIHttpTrigger/validation.py
@@ -14,12 +14,18 @@ from models import error
 
 
 def check_query_parameters(
-    countries, filters, length_of_course, limit, max_default_limit, offset
+    countries, filters, length_of_course, subjects, limit, max_default_limit, offset
 ):
 
     try:
         validator = Validator(
-            countries, filters, length_of_course, limit, max_default_limit, offset
+            countries,
+            filters,
+            length_of_course,
+            subjects,
+            limit,
+            max_default_limit,
+            offset,
         )
 
         return validator.validate()
@@ -29,7 +35,14 @@ def check_query_parameters(
 
 class Validator:
     def __init__(
-        self, countries, filters, length_of_course, limit, max_default_limit, offset
+        self,
+        countries,
+        filters,
+        length_of_course,
+        subjects,
+        limit,
+        max_default_limit,
+        offset,
     ):
         self.max_default_limit = max_default_limit
         self.limit = limit
@@ -37,6 +50,7 @@ class Validator:
         self.filters = filters
         self.length_of_course = length_of_course
         self.countries = countries
+        self.subjects = subjects
 
     def validate(self):
         error_objects = []
@@ -44,9 +58,7 @@ class Validator:
         self.new_offset, o_error_objects = self.validate_offset()
         self.new_filters, f_error_objects = self.validate_filters()
         self.new_countries, c_error_objects = self.validate_countries()
-        self.new_length_of_courses, loc_error_objects = (
-            self.validate_length_of_courses()
-        )
+        self.new_length_of_course, loc_error_objects = self.validate_length_of_courses()
 
         # Combine error objects
         error_objects.extend(
@@ -254,7 +266,7 @@ class Validator:
 
         loc = self.length_of_course.split(",")
 
-        length_of_courses, invalid_type, out_of_range = [], [], []
+        length_of_course, invalid_type, out_of_range = [], [], []
         for length in loc:
             length_is_int, l = is_int(length)
             if not length_is_int:
@@ -264,11 +276,11 @@ class Validator:
             if l < 1 or l > 7:
                 out_of_range.append(length)
 
-            length_of_courses.append(l)
+            length_of_course.append(str(l))
 
         if len(invalid_type) > 0:
             value = ",".join(invalid_type)
-            error_values = [{"key": "length_of_courses", "value": value}]
+            error_values = [{"key": "length_of_course", "value": value}]
 
             error_object = error.get_error_object(
                 error.ERR_LENGTH_OF_COURSE_WRONG_TYPE, error_values
@@ -277,7 +289,7 @@ class Validator:
 
         if len(out_of_range) > 0:
             value = ",".join(out_of_range)
-            error_values = [{"key": "length_of_courses", "value": value}]
+            error_values = [{"key": "length_of_course", "value": value}]
 
             error_object = error.get_error_object(
                 error.ERR_LENGTH_OF_COURSE_OUT_OF_RANGE, error_values
@@ -288,7 +300,7 @@ class Validator:
         if len(error_objects) > 0:
             return [], error_objects
 
-        return length_of_courses, []
+        return length_of_course, []
 
     def build_query_params(self):
         query_params = {}
@@ -303,8 +315,12 @@ class Validator:
         if len(self.new_countries) > 0:
             query_params["countries"] = self.new_countries
 
-        if len(self.new_length_of_courses) > 0:
-            query_params["length_of_courses"] = self.new_length_of_courses
+        if len(self.new_length_of_course) > 0:
+            query_params["length_of_course"] = self.new_length_of_course
+
+        if self.subjects != "":
+            subjects = self.subjects.upper().split(",")
+            query_params["subjects"] = subjects
 
         self.query_params = query_params
 

--- a/swagger.yml
+++ b/swagger.yml
@@ -292,7 +292,7 @@ components:
         type: string
     countries:
       description: |
-        A commar separated list of countries' to filter by. Only the following enumerations are filterable (case insensitive):
+        A comma separated list of countries' to filter by. Only the following enumerations are filterable (case insensitive):
           * england
           * northern_ireland
           * wales
@@ -307,7 +307,7 @@ components:
         type: string
     institutions:
       description: |
-        A commar separated list of institutions' to filter by. Only institutions which directly match the stored values will be returned ignoring casing
+        A comma separated list of institutions' to filter by. Only institutions which directly match the stored values will be returned ignoring casing
       example: "Didsbury Manchester,Roehampton University"
       in: query
       name: institutions
@@ -316,7 +316,7 @@ components:
         type: string
     subjects:
       description: |
-        A commar separated list of subjects' to filter by. Only subject codes which directly match the stored values will be returned ignoring casing
+        A comma separated list of subjects' to filter by. Only subject codes which directly match the stored values will be returned ignoring casing
       example: "CAH09-01-01,cah11-01-01"
       in: query
       name: subjects
@@ -325,7 +325,7 @@ components:
         type: string
     filters:
       description: |
-        A commar separated list of filters' to filter all courses by. Only the following enumerations are filterable (case insensitive):
+        A comma separated list of filters' to filter all courses by. Only the following enumerations are filterable (case insensitive):
           * part_time
           * full_time
           * distance_learning

--- a/swagger.yml
+++ b/swagger.yml
@@ -18,6 +18,7 @@ paths:
         - $ref: '#/components/parameters/filters'
         - $ref: '#/components/parameters/countries'
         - $ref: '#/components/parameters/institutions'
+        - $ref: '#/components/parameters/subjects'
         - $ref: '#/components/parameters/postcode'
       responses:
         200:
@@ -128,7 +129,7 @@ components:
           description: "The total number of stages for the course."
           type: string
         locations:
-          description: ""
+          description: "A list of teaching location that the course is taught at."
           type: array
           items:
             $ref: '#/components/schemas/location'
@@ -140,7 +141,11 @@ components:
         sandwich_year:
           description: "The availability of a sandwich year/work placement."
           type: string
-        
+        subjects:
+          description: "A list of subjects that the course relates too."
+          type: array
+          items:
+            $ref: '#/components/schemas/subject'
         title:
           description: "The title given to course by institution."
           required: [
@@ -188,6 +193,33 @@ components:
       description: "The short name (alias) of the course qualification."
       type: string
       example: "BSc"
+    subject:
+      description: "Sub document containing information on subject."
+      required: [
+        code
+        english
+        level
+      ]
+      type: object
+      properties:
+        code:
+          description: "The code that uniquely identifies subject."
+          type: string
+          example: "CAH09"
+        english:
+          description: "The english name for subject."
+          type: string
+        level:
+          description: "The hierarchy (also known as aggregation) level of subject."
+          type: integer
+          enum: [
+            1,
+            2,
+            3
+          ]
+        welsh:
+          description: "The welsh name for subject."
+          type: string
     errorResponse:
       description: "The error response body, contains specific details of why the request failed"
       type: object
@@ -279,6 +311,15 @@ components:
       example: "Didsbury Manchester,Roehampton University"
       in: query
       name: institutions
+      required: false
+      schema:
+        type: string
+    subjects:
+      description: |
+        A commar separated list of subjects' to filter by. Only subject codes which directly match the stored values will be returned ignoring casing
+      example: "CAH09-01-01,cah11-01-01"
+      in: query
+      name: subjects
       required: false
       schema:
         type: string


### PR DESCRIPTION
### What

Include subject codes to filters

### How to review

Check in pre-prod API Management that you can add new filter `subjects` (this should equate to a comma separated list of subject codes) to return courses that are related to that subject
