### PR TITLE
Handle commas and ampersands sent through for search querying

### DIFF
--- a/CourseSearchAPIHttpTrigger/query.py
+++ b/CourseSearchAPIHttpTrigger/query.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import re
 
 
 def build_course_search_query(
@@ -45,8 +46,10 @@ class Query:
             search.append(institution_search_query)
 
         if self.course:
-            course_search_query = "course/title/english:" + self.course
-            search.append(course_search_query)
+            english_course_search_query = "course/title/english:" + self.course
+            welsh_course_search_query = "course/title/welsh:" + self.course
+            search.append(english_course_search_query)
+            search.append(welsh_course_search_query)
 
         if search:
             query += "&search=" + " ".join(search) + "&queryType=full"
@@ -123,11 +126,14 @@ class Query:
                 filters.append("course/year_abroad/code ne 2")
 
         if self.institutions != "":
-            institutions = self.institutions.split(",")
+            institutions = re.split(r',(?=")', self.institutions)
 
             institution_list = list()
             search_public_ukprn = os.environ["SearchPubUKPRN"]
             for institution in institutions:
+                institution = institution.strip('\"')
+                institution = institution.replace("&", "%26")
+
                 if search_public_ukprn == "False":
                     institution_list.append(
                         "course/institution/pub_ukprn_name eq '" + institution + "'"


### PR DESCRIPTION
Specifically institutions that are comma separated yet the values include commas

### What

See title

### How to review

Run the api locally and point you service to pre-prod. Check the use of ampersands and commas for institutions filter, for example:

http://localhost:7071/api/CourseSearchAPIHttpTrigger?institutions="%22REDCAR%20%26%20CLEVELAND%20COLLEGE%22"

Ampersands need to be url encoded before being sent to search API (criteria for front end website)
