### PR TITLE
fixed-institution-tests

### DIFF
--- a/CourseSearchAPIHttpTrigger/query.py
+++ b/CourseSearchAPIHttpTrigger/query.py
@@ -136,31 +136,50 @@ class Query:
             for x in institution_filter_list:
                 filters.append(x)
 
-        if self.postcode_object != {}:
-            latitude = self.postcode_object["latitude"]
-            longitude = self.postcode_object["longitude"]
-            distance = self.postcode_object["distance"]
-
-            filters.append(
-                "course/locations/any(location: geo.distance(\
-                           location/geo, geography'POINT("
-                + str(longitude)
-                + " "
-                + str(latitude)
-                + ")') le "
-                + distance
-                + ")"
-            )
-
         #Condition that will remove distance learning from the filters, and run a function for a separate distance learning filter
         if '(course/distance_learning/code eq 0 or course/distance_learning/code eq 1 or course/distance_learning/code eq 2)' in filters:    
             distance_filter = Query.build_or_distance_filter(self.query_params, filters)
             filters.remove(f'(course/distance_learning/code eq 0 or course/distance_learning/code eq 1 or course/distance_learning/code eq 2)')
             filters.append(f'course/distance_learning/code ne 1')
+            
+
+            if self.postcode_object != {}:
+                latitude = self.postcode_object["latitude"]
+                longitude = self.postcode_object["longitude"]
+                distance = self.postcode_object["distance"]
+
+                filters.append(
+                    "course/locations/any(location: geo.distance(\
+                               location/geo, geography'POINT("
+                    + str(longitude)
+                    + " "
+                    + str(latitude)
+                    + ")') le "
+                    + distance
+                    + ")"
+                )
+
             filter_query = " and ".join(filters)
             filter_query += " or "
             filter_query += " and ".join(distance_filter)
         else:
+
+            if self.postcode_object != {}:
+                latitude = self.postcode_object["latitude"]
+                longitude = self.postcode_object["longitude"]
+                distance = self.postcode_object["distance"]
+
+                filters.append(
+                    "course/locations/any(location: geo.distance(\
+                               location/geo, geography'POINT("
+                    + str(longitude)
+                    + " "
+                    + str(latitude)
+                    + ")') le "
+                    + distance
+                    + ")"
+                )
+
             filter_query = " and ".join(filters)
 
         if filter_query != "":
@@ -252,7 +271,7 @@ class Query:
 
     def build_institution_filter(institutions, query_params):
         institution_filters = list()
-        split_institutions = institutions.split("#")
+        split_institutions = institutions.split("@")
         institution_list = list()
         search_public_ukprn = os.environ["SearchPubUKPRN"]
 

--- a/CourseSearchAPIHttpTrigger/tests/test_query.py
+++ b/CourseSearchAPIHttpTrigger/tests/test_query.py
@@ -137,7 +137,7 @@ class TestInsitituionFilter(unittest.TestCase):
 
     @mock.patch.dict(os.environ, {"SearchPubUKPRN": "False"})
     def test_with_multiple_institutions_selected(self):
-        self.institutions = 'University of Southampton#University Two#University Three'
+        self.institutions = 'University of Southampton@University Two@University Three'
         self.query_params["language"] = {}
         build_array = Query.build_institution_filter(self.institutions, self.query_params)
         expected = [f"({self.doc} 'University of Southampton' or {self.doc} 'University Two' or {self.doc} 'University Three')"]
@@ -145,7 +145,7 @@ class TestInsitituionFilter(unittest.TestCase):
 
     @mock.patch.dict(os.environ, {"SearchPubUKPRN": "False"})
     def test_with_multiple_institutions_welsh(self):
-        self.institutions = 'University of Southampton#University Two#University Three'
+        self.institutions = 'University of Southampton@University Two@University Three'
         self.query_params["language"] = 'cy'
         build_array = Query.build_institution_filter(self.institutions, self.query_params)
         expected = [f"({self.doc_cy} 'University of Southampton' or {self.doc_cy} 'University Two' or {self.doc_cy} 'University Three')"]
@@ -153,7 +153,7 @@ class TestInsitituionFilter(unittest.TestCase):
 
     @mock.patch.dict(os.environ, {"SearchPubUKPRN": "True"})
     def test_multiple_with_SearchPubUKPRN_set_true(self):
-        self.institutions = 'University of Southampton#University Two#University Three'
+        self.institutions = 'University of Southampton@University Two@University Three'
         self.query_params["language"] = 'cy'
         build_array = Query.build_institution_filter(self.institutions, self.query_params)
         expected = [f"({self.doc_ukprn} 'University of Southampton' or {self.doc_ukprn} 'University Two' or {self.doc_ukprn} 'University Three')"]


### PR DESCRIPTION
When searching with  distance learning and on campus both either checked or unchecked, the postcode filter will not be included in the distance learning filter.

Changed the institution array to split on @ to tidy up the wagtail-CMS views - cannot use a comma as some institutions have a comma in their name.
