### PR TITLE
Switch from url to body

### DIFF
--- a/CourseSearchAPIHttpTrigger/__init__.py
+++ b/CourseSearchAPIHttpTrigger/__init__.py
@@ -93,7 +93,10 @@ def main(req: func.HttpRequest) -> func.HttpResponse:
         institution = req.params.get("qi", "")
         filters = req.params.get("filters", "")
         postcode_and_distance = req.params.get("postcode", "")
-        institutions = req.params.get("institutions", "")
+        print(f"GET BODY {type(req.get_json())}")
+        institution_list = req.get_json().get('institutions', [])
+        institution_string = "@".join(institution_list)
+        institutions = institution_string
         countries = req.params.get("countries", "")
         length_of_course = req.params.get("length_of_course", "")
         subjects = req.params.get("subjects", "")
@@ -169,7 +172,7 @@ def main(req: func.HttpRequest) -> func.HttpResponse:
         response_with_facets = get_courses(
             search_url, api_key, api_version, course_index_name, search_query
         )
-
+        print("SEARRCH", search_url)
         facets = response_with_facets.json()
 
         counts = {}

--- a/CourseSearchAPIHttpTrigger/__init__.py
+++ b/CourseSearchAPIHttpTrigger/__init__.py
@@ -93,7 +93,6 @@ def main(req: func.HttpRequest) -> func.HttpResponse:
         institution = req.params.get("qi", "")
         filters = req.params.get("filters", "")
         postcode_and_distance = req.params.get("postcode", "")
-        print(f"GET BODY {type(req.get_json())}")
         institution_list = req.get_json().get('institutions', [])
         institution_string = "@".join(institution_list)
         institutions = institution_string
@@ -172,7 +171,7 @@ def main(req: func.HttpRequest) -> func.HttpResponse:
         response_with_facets = get_courses(
             search_url, api_key, api_version, course_index_name, search_query
         )
-        print("SEARRCH", search_url)
+
         facets = response_with_facets.json()
 
         counts = {}

--- a/CourseSearchAPIHttpTrigger/query.py
+++ b/CourseSearchAPIHttpTrigger/query.py
@@ -51,8 +51,10 @@ class Query:
         if self.course:
             english_course_search_query = "course/title/english:" + self.course
             welsh_course_search_query = "course/title/welsh:" + self.course
-            search.append(english_course_search_query)
-            search.append(welsh_course_search_query)
+            if self.query_params["language"] == "cy":
+                search.append(welsh_course_search_query)
+            else:
+                search.append(english_course_search_query)
 
         if search:
             query_dict["search"] = " ".join(search)

--- a/CourseSearchAPIHttpTrigger/query.py
+++ b/CourseSearchAPIHttpTrigger/query.py
@@ -34,7 +34,7 @@ class Query:
         self.query_params = query_params
 
     def build(self):
-        query = ""
+        query_dict = {}
         # Create search part of query
         search = list()
         if self.institution:
@@ -55,9 +55,13 @@ class Query:
             search.append(welsh_course_search_query)
 
         if search:
-            query += "&search=" + " ".join(search) + "&queryType=full"
+            query_dict["search"] = " ".join(search)
         else:
-            query += "&search=*"
+            query_dict["search"] = "*"
+
+        query_dict["queryType"] = "full"
+        query_dict["searchMode"] = "all"
+
 
         # Create filter part of query
         filters = list()
@@ -183,41 +187,43 @@ class Query:
             filter_query = " and ".join(filters)
 
         if filter_query != "":
-            query += "&$filter=" + filter_query
+            query_dict["filter"]=filter_query
+
 
         # Add alphabetic ordering based on the institution name after
         # ordering by search score
-        query += "&$orderby=course/institution/sort_pub_ukprn_welsh_name" if self.query_params["language"] == "cy" else "&$orderby=course/institution/sort_pub_ukprn_name"
+        if self.query_params["language"] == "cy":
+            query_dict["orderby"] = "course/institution/sort_pub_ukprn_welsh_name"
+        else:
+            query_dict["orderby"] = "course/institution/sort_pub_ukprn_name"
 
-        self.query = query
+        self.query = query_dict
 
     def add_paging(self):
-        query = self.query
-
+        result = dict()
         # Add limit and offset parameters
         if "limit" in self.query_params:
-            query += "&$top=" + str(self.query_params["limit"])
+            result["top"]=str(self.query_params["limit"])
 
         if "offset" in self.query_params:
-            query += "&$skip=" + str(self.query_params["offset"])
+            result["skip"]=str(self.query_params["offset"])
 
-        return query
+        return {**self.query, **result}
 
     def add_facet(self):
-        query = self.query
 
         # Set top to be zero
-        query += "&$top=0"
+        result = dict(top=0)
 
         # Build facet query for categorising courses by institution
         if self.query_params["language"] == "cy":
-            query += "&facet=course/institution/sort_pub_ukprn_welsh_name,\
-                count:500, sort:value"
+            result["facets"]=["course/institution/sort_pub_ukprn_welsh_name,\
+                count:500, sort:value"]
         else:
-            query += "&facet=course/institution/sort_pub_ukprn_name,\
-                count:500,sort:value"
+            result["facets"]=["course/institution/sort_pub_ukprn_name,\
+                count:500,sort:value"]
 
-        return query
+        return {**self.query, **result}
 
     def build_distance_learning_filter(query_params):
         on_campus = query_params.get('on_campus')

--- a/CourseSearchAPIHttpTrigger/search.py
+++ b/CourseSearchAPIHttpTrigger/search.py
@@ -69,7 +69,7 @@ class PostcodeIndex:
 
 def get_courses(url, api_key, api_version, index_name, search_query):
     index = CourseIndex(url, api_key, api_version, index_name, search_query)
-    print(search_query)
+    
     return index.get()
 
 


### PR DESCRIPTION
The filters were originally being retrieved via a query string in the url - when the url was too long, the search query was failing. With the help of Simon, to fix this we have:

Switched the get request to a post request.

Removed the filters query string from the url and added the filters to the body of the request instead.

