### PR TITLE
added post to functions.json

### DIFF
--- a/CourseSearchAPIHttpTrigger/function.json
+++ b/CourseSearchAPIHttpTrigger/function.json
@@ -7,7 +7,8 @@
       "direction": "in",
       "name": "req",
       "methods": [
-        "get"
+        "get",
+        "post"
       ]
     },
     {


### PR DESCRIPTION
Allow Azure to accept get and post requests for the CourseSearchAPIHttpTrigger.
