### PR TITLE
fixing ampersand in search query

### DIFF
--- a/CourseSearchAPIHttpTrigger/query.py
+++ b/CourseSearchAPIHttpTrigger/query.py
@@ -278,7 +278,6 @@ class Query:
 
         for institution in split_institutions:
             institution = institution.strip('"')
-            institution = institution.replace("&", "%26")
 
             if search_public_ukprn == "False":
                 if query_params["language"] == "cy":


### PR DESCRIPTION
When the search query was performed in the URL, any "&" had to be replaced by it's code for the query to work. We now need to remove this.
